### PR TITLE
fix: ignore exit code 1

### DIFF
--- a/denops/@ddc-sources/rg/main.ts
+++ b/denops/@ddc-sources/rg/main.ts
@@ -43,7 +43,7 @@ export class Source extends BaseSource<Params> {
       proc.status,
     ]);
 
-    if (!status.success) {
+    if (status.code >= 2) {
       console.error("[ddc-rg] rg exited with non-zero status");
       if (stderr.length > 0) {
         console.error(stderr);


### PR DESCRIPTION
## Summary

Treat exit code of 1 as any match exists.

## Details

`ripgrep` exits with status 1 if there are 0 matches.
So we you check with `success`, `[ddc-rg] rg exited with non-zero status` will be displayed every loop.

> 1 exit status occurs only when no match was found and no error occurred.

<https://github.com/BurntSushi/ripgrep/blob/d5b85d44057ff729a89be9c6549958c45d95aa99/crates/core/flags/doc/template.rg.1#L135>

## Confirmation

The error log shown at commit b55358a55929bb81fdfe2a6f5cad18e69d1fc11b does not appear at commit 7e1a56ab5f2eacfab008d9b13bfc2bf4c2e5ef80.

## Limitation

None.